### PR TITLE
MMMLoadableGroup: replace .never failure mode with a new .any group mode

### DIFF
--- a/MMMLoadable.podspec
+++ b/MMMLoadable.podspec
@@ -1,12 +1,12 @@
 #
 # MMMLoadable. Part of MMMTemple.
-# Copyright (C) 2015-2020 MediaMonks. All rights reserved.
+# Copyright (C) 2015-2022 MediaMonks. All rights reserved.
 #
 
 Pod::Spec.new do |s|
 
   s.name = "MMMLoadable"
-  s.version = "1.7.1"
+  s.version = "1.8.0"
   s.summary = "A simple model for async calculations"
   s.description = "#{s.summary}."
   s.homepage = "https://github.com/mediamonks/#{s.name}"
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
   s.watchos.deployment_target = '3.0'
-  s.tvos.deployment_target = '9.0'
+  s.tvos.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
 
   s.subspec 'ObjC' do |ss|
@@ -40,9 +40,10 @@ Pod::Spec.new do |s|
   end
 
   s.test_spec 'Tests' do |ss|
-	  ss.ios.deployment_target = '11.0'
+    ss.ios.deployment_target = '11.0'
     ss.source_files = "Tests/*.{m,swift}"
+    ss.requires_app_host = true
   end
 
-	s.default_subspec = 'ObjC', 'Swift'
+  s.default_subspec = 'ObjC', 'Swift'
 end

--- a/Sources/MMMLoadable/MMMLoadable.swift
+++ b/Sources/MMMLoadable/MMMLoadable.swift
@@ -10,9 +10,8 @@ import MMMCommonCore
 @_exported import MMMLoadableObjC
 #endif
 
-extension MMMLoadableState: CustomDebugStringConvertible {
-	
-	public var debugDescription: String { NSStringFromMMMLoadableState(self) }
+extension MMMLoadableState: CustomStringConvertible {
+	public var description: String { NSStringFromMMMLoadableState(self) }
 }
 
 extension MMMPureLoadableProtocol {

--- a/Sources/MMMLoadableObjC/MMMLoadable+Subclasses.h
+++ b/Sources/MMMLoadableObjC/MMMLoadable+Subclasses.h
@@ -14,7 +14,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** 
- * Parts of the base lodable accessible to subclasses.
+ * Parts of the base loadable accessible to subclasses.
  */
 @interface MMMLoadable (Subclasses)
 
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Note that the contents of the group can be changed by subclasses any time after the initialization
  * (and this can be done more than once), so a nil can be passed to the designated initializer and then
- * this property can be adjusted after subobjects are initialized. */
+ * this property can be adjusted after sub-objects are initialized. */
 @property (nonatomic, readwrite) NSArray<id<MMMPureLoadable>> *loadables;
 
 - (void)notifyDidChange;

--- a/Sources/MMMLoadableObjC/MMMLoadableImage.h
+++ b/Sources/MMMLoadableObjC/MMMLoadableImage.h
@@ -38,7 +38,7 @@ API_AVAILABLE(ios(11)) @interface MMMNamedLoadableImage : MMMLoadable <MMMLoadab
 @end
 
 /**
- * MMMLoadableImage-compatible wrapper for images that are immediatey available.
+ * MMMLoadableImage-compatible wrapper for images that are immediately available.
  */
 API_AVAILABLE(ios(11)) @interface MMMImmediateLoadableImage : MMMLoadable <MMMLoadableImage>
 
@@ -49,7 +49,7 @@ API_AVAILABLE(ios(11)) @interface MMMImmediateLoadableImage : MMMLoadable <MMMLo
 @end
 
 /** 
- * Implementation of MMMLoadableImage for images that are publically accessible via a URL.
+ * Implementation of MMMLoadableImage for images that are publicly accessible via a URL.
  * This is very basic, using the shared instance of NSURLSession, so any caching will happen there.
  */
 API_AVAILABLE(ios(11)) @interface MMMPublicLoadableImage : MMMLoadable <MMMLoadableImage>
@@ -77,7 +77,7 @@ API_AVAILABLE(ios(11)) @interface MMMTestLoadableImage : MMMTestLoadable <MMMLoa
  * or request a sync asap. Later when the actual reference is finally available it is supplied to the proxy which begins
  * mirroring its state.
  *
- * As always, this is meant to be used only in the implementation, with only id<MMMLoadableImage> visible publically.
+ * As always, this is meant to be used only in the implementation, with only id<MMMLoadableImage> visible publicly.
  */
 API_AVAILABLE(ios(11)) @interface MMMLoadableImageProxy : MMMLoadableProxy <MMMLoadableImage>
 

--- a/Tests/MMMLoadableTestCase.swift
+++ b/Tests/MMMLoadableTestCase.swift
@@ -1,0 +1,229 @@
+//
+// MMMLoadable. Part of MMMTemple.
+// Copyright (C) 2016-2020 MediaMonks. All rights reserved.
+//
+
+import MMMCommonCore
+import MMMLoadable
+import XCTest
+
+class MMMLoadableTestCase: XCTestCase {
+
+	func testGroup() {
+		
+		XCTAssertEqual(
+			groupTruthTable(mode: .all),
+			"""
+			### isContentsAvailable
+			
+			false <- [false, false]
+			false <- [false, true]
+			false <- [true, false]
+			true <- [true, true]
+			
+			### loadableState
+			
+			idle <- [idle, idle]
+			idle <- [idle, did-sync-successfully]
+			idle <- [did-sync-successfully, idle]
+			syncing <- [idle, syncing]
+			syncing <- [syncing, idle]
+			syncing <- [syncing, syncing]
+			syncing <- [syncing, did-sync-successfully]
+			syncing <- [did-sync-successfully, syncing]
+			did-sync-successfully <- [did-sync-successfully, did-sync-successfully]
+			did-fail-to-sync <- [idle, did-fail-to-sync]
+			did-fail-to-sync <- [syncing, did-fail-to-sync]
+			did-fail-to-sync <- [did-sync-successfully, did-fail-to-sync]
+			did-fail-to-sync <- [did-fail-to-sync, idle]
+			did-fail-to-sync <- [did-fail-to-sync, syncing]
+			did-fail-to-sync <- [did-fail-to-sync, did-sync-successfully]
+			did-fail-to-sync <- [did-fail-to-sync, did-fail-to-sync]
+			
+			"""
+		)
+
+		XCTAssertEqual(
+			groupTruthTable(mode: .any),
+			"""
+			### isContentsAvailable
+
+			false <- [false, false]
+			true <- [false, true]
+			true <- [true, false]
+			true <- [true, true]
+
+			### loadableState
+
+			idle <- [idle, idle]
+			idle <- [idle, did-fail-to-sync]
+			idle <- [did-fail-to-sync, idle]
+			syncing <- [idle, syncing]
+			syncing <- [syncing, idle]
+			syncing <- [syncing, syncing]
+			syncing <- [syncing, did-sync-successfully]
+			syncing <- [syncing, did-fail-to-sync]
+			syncing <- [did-sync-successfully, syncing]
+			syncing <- [did-fail-to-sync, syncing]
+			did-sync-successfully <- [idle, did-sync-successfully]
+			did-sync-successfully <- [did-sync-successfully, idle]
+			did-sync-successfully <- [did-sync-successfully, did-sync-successfully]
+			did-sync-successfully <- [did-sync-successfully, did-fail-to-sync]
+			did-sync-successfully <- [did-fail-to-sync, did-sync-successfully]
+			did-fail-to-sync <- [did-fail-to-sync, did-fail-to-sync]
+			
+			"""
+		)
+
+		// This is what the former `MMMLoadableGroupFailurePolicyNever` would produce.
+		// Note the issue with isContentsAvailable still depending on all objects which causes it to be `false`
+		// when the composite state is `did-sync-successfully`.
+		XCTAssertEqual(
+			groupTruthTable(mode: .__deprecated),
+			"""
+			### isContentsAvailable
+
+			false <- [false, false]
+			false <- [false, true]
+			false <- [true, false]
+			true <- [true, true]
+
+			### loadableState
+
+			idle <- [idle, idle]
+			idle <- [idle, did-sync-successfully]
+			idle <- [idle, did-fail-to-sync]
+			idle <- [did-sync-successfully, idle]
+			idle <- [did-fail-to-sync, idle]
+			syncing <- [idle, syncing]
+			syncing <- [syncing, idle]
+			syncing <- [syncing, syncing]
+			syncing <- [syncing, did-sync-successfully]
+			syncing <- [syncing, did-fail-to-sync]
+			syncing <- [did-sync-successfully, syncing]
+			syncing <- [did-fail-to-sync, syncing]
+			did-sync-successfully <- [did-sync-successfully, did-sync-successfully]
+			did-sync-successfully <- [did-sync-successfully, did-fail-to-sync]
+			did-sync-successfully <- [did-fail-to-sync, did-sync-successfully]
+			did-sync-successfully <- [did-fail-to-sync, did-fail-to-sync]
+			
+			"""
+		)
+	}
+	
+	private func groupTruthTable(mode: MMMLoadableGroupMode) -> String {
+	
+		var result: String = ""
+		
+		print("### isContentsAvailable\n", to: &result)
+		print(
+			truthTable(
+				groupMode: mode,
+				values: [false, true]
+			) { group, pairs in
+				// isContentsAvailable Is recalculated only with state changes, thus need to flip
+				// the composite state back and forth.
+				for (o, v) in pairs {
+					o.isContentsAvailable = v
+					o.setSyncing()
+				}
+				for (o, _) in pairs {
+					o.setDidFailToSyncWithError(nil)
+				}
+				return group.isContentsAvailable
+			},
+			to: &result
+		)
+		
+		print("\n### loadableState\n", to: &result)
+		print(
+			truthTable(
+				groupMode: mode,
+				values: [.idle, .syncing, .didFailToSync, .didSyncSuccessfully] as [MMMLoadableState]
+			) { group, pairs in
+				for (o, v) in pairs {
+					o.loadableState = v
+				}
+				return group.loadableState
+			},
+			to: &result
+		)
+		
+		return result
+	}
+	
+	private struct TruthTable<T: Comparable>: CustomStringConvertible {
+	
+		public let rows: [TruthTableRow<T>]
+		
+		public var description: String {
+			// Need to sorting because we are randomizing order while testing.
+			let sorted = rows.sorted {
+				if $0.output < $1.output {
+					return true
+				} else if $0.output == $1.output {
+					// Arrays are not Comparable.
+					for (a, b) in zip($0.inputs, $1.inputs) {
+						if a < b {
+							return true
+						} else if a > b {
+							return false
+						}
+					}
+					return false
+				} else {
+					return false
+				}
+			}
+			return sorted.map(String.init(describing:)).joined(separator: "\n")
+		}
+	}
+	
+	private struct TruthTableRow<T: Comparable>: Equatable, CustomStringConvertible {
+
+		public let inputs: [T]
+		public let output: T
+		
+		public init(_ inputs: [T], _ output: T) {
+			self.inputs = inputs
+			self.output = output
+		}
+		
+		public var description: String {
+			"\(output) <- \(inputs)"
+		}
+	}
+
+	private func truthTable<T: Comparable>(
+		groupMode: MMMLoadableGroupMode,
+		values: [T],
+		assign: (MMMLoadableGroup, [(MMMTestLoadable, T)]) -> T
+	) -> TruthTable<T> {
+	
+		let c1 = MMMTestLoadable()
+		let c2 = MMMTestLoadable()
+		let group = MMMLoadableGroup(loadables: [c1, c2], mode: groupMode)
+		
+		var rows: [TruthTableRow<T>] = []
+		// Shuffling to avoid dependency on the order.
+		for v1 in values.shuffled() {
+			for v2 in values.shuffled() {
+				let output = assign(group, [(c1, v1), (c2, v2)])
+				rows.append(.init([v1, v2], output))
+			}
+		}
+		return .init(rows: rows)
+	}
+}
+
+extension MMMLoadableState: Comparable {
+	public static func < (lhs: MMMLoadableState, rhs: MMMLoadableState) -> Bool {
+		lhs.rawValue < rhs.rawValue
+	}
+}
+
+extension Bool: Comparable {
+	public static func < (lhs: Bool, rhs: Bool) -> Bool {
+		!lhs && rhs
+	}
+}


### PR DESCRIPTION
Improving the `.never` failure policy for groups that was less useful in general and caused confusion around `isContentsAvailable`.