### PR TITLE
Add checking availability for webp animation

### DIFF
--- a/MMMLoadable.podspec
+++ b/MMMLoadable.podspec
@@ -6,7 +6,7 @@
 Pod::Spec.new do |s|
 
   s.name = "MMMLoadable"
-  s.version = "2.2.1"
+  s.version = "2.2.2"
   s.summary = "A simple model for async calculations"
   s.description = "#{s.summary}."
   s.homepage = "https://github.com/mediamonks/#{s.name}"

--- a/Sources/MMMLoadableObjC/MMMLoadableImage.m
+++ b/Sources/MMMLoadableObjC/MMMLoadableImage.m
@@ -224,7 +224,10 @@ API_AVAILABLE(ios(11)) @implementation MMMPublicLoadableImage {
 		return nil;
 	}
 	NSDictionary *gifProps = (__bridge NSDictionary *)(CFDictionaryRef)CFDictionaryGetValue(props, kCGImagePropertyGIFDictionary);
-	NSDictionary *webpProps = (__bridge NSDictionary *)(CFDictionaryRef)CFDictionaryGetValue(props, kCGImagePropertyWebPDictionary);
+	NSDictionary *webpProps = nil;
+	if (@available(iOS 14.0, *)) {
+		webpProps = (__bridge NSDictionary *)(CFDictionaryRef)CFDictionaryGetValue(props, kCGImagePropertyWebPDictionary);
+	}
 	CFRelease(props);
 	if (gifProps) {
 		return (NSNumber *)gifProps[(NSString *)kCGImagePropertyGIFDelayTime];
@@ -270,7 +273,7 @@ API_AVAILABLE(ios(11)) @implementation MMMPublicLoadableImage {
 		[images addObject:image];
 	}
 
-	NSTimeInterval delayTime = MAX([delayTimeNum doubleValue], 0.1);
+	NSTimeInterval delayTime = MAX([delayTimeNum doubleValue], 0.04);
 
 	UIImage *result = [UIImage animatedImageWithImages:images duration:delayTime * count];
 


### PR DESCRIPTION
There was an issue here that the webp format is supported from iOS 14 and higher. Therefore, a runtime error could appear if you run the code on iOS 13 and lower. 
Also along the way, the minimum FPS was increased to 25, since some animations had it and looked very slow using previous value.